### PR TITLE
Adding MockCameraControl

### DIFF
--- a/lib/stub_camera_control.coffee
+++ b/lib/stub_camera_control.coffee
@@ -4,20 +4,33 @@ fs = require("fs")
 ###
 # Fake camera controller for frontend testing.
 ###
-class MockCameraControl
+class StubCameraControl
   emitter: new EventEmitter()
   paths:
-    cwd: "public/photos",
+    cwd: "public/tmp",
     web: "/photos"
+    fixtures: "test/fixtures",
+    photo_file: "test_photo.jpg",
+    preview_file: "test_photo_preview.jpg"
+
   init: ->
     @emitter.on("snap", =>
       @emitter.emit "camera_begin_snap"
       @emitter.emit "camera_snapped"
 
-      # copy to cwd URL
-      # copy to web URL
+      fs.renameSync(
+        "#{@paths.fixtures}/#{@paths.photo_file}",
+        "#{@paths.cwd}/#{@paths.photo_file}"
+      )
+
+      # copy to web preview URL
+      fs.renameSync(
+        "#{@paths.fixtures}/#{@paths.preview_file}",
+        "#{@paths.cwd}/#{@paths.preview_file}"
+      )
+
       @emitter.emit "photo_saved"
     )
     @emitter
 
-module.exports = MockCameraControl
+module.exports = StubCameraControl

--- a/test/stub_camera_control_test.coffee
+++ b/test/stub_camera_control_test.coffee
@@ -1,9 +1,16 @@
 expect = require("chai").expect
 sinon = require("sinon")
-StubCameraControl = require "../lib/stub_camera_control"
+rewire = require("rewire")
+fs = require "fs"
+StubCameraControl = rewire "../lib/stub_camera_control"
 EventEmitter = require("events").EventEmitter
 
 describe "StubCameraControl", ->
+
+  mockFs = sinon.stub(fs)
+
+  beforeEach ->
+    StubCameraControl.__set__("fs", mockFs)
 
   describe "constructor", ->
     it "returns instance of MCC", ->
@@ -32,13 +39,27 @@ describe "StubCameraControl", ->
 
         expect(spy.called).to.be.true
 
-      xit "emits 'photo_saved' with save metadata", ->
-        spy = sinon.spy()
-        subject.on("photo_saved", spy)
-        subject.emit "snap"
-        expect(spy.called).to.be.true
-        fname = "mockCameraPhoto.jpg"
-        cwdPath = "public/photos/#{fname}"
-        webUrl = "/photos/#{fname}"
-        expect(spy.calledWith(fname, cwdPath, webUrl)).to.be.true
+
+      describe "when simulating gphoto save", ->
+        it "moves a fixture file to the public directory", ->
+          mockFs.expects("renameSync")
+            .withArgs("test/fixtures/test_photo.jpg", "public/tmp/test_photo.jpg")
+          subject.emit "snap"
+          mockFs.verify()
+
+        it "moves the preview file to the public direcotry", ->
+          mockFs.expects("renameSync")
+            .withArgs("test/fixtures/test_photo_preview.jpg", "public/tmp/test_photo_preview.jpg")
+          subject.emit "snap"
+          mockFs.verify()
+
+        it "emits 'photo_saved' with save metadata", ->
+          spy = sinon.spy()
+          subject.on("photo_saved", spy)
+          subject.emit "snap"
+          expect(spy.called).to.be.true
+          fname = "mockCameraPhoto.jpg"
+          cwdPath = "public/photos/#{fname}"
+          webUrl = "/photos/#{fname}"
+          expect(spy.calledWith(fname, cwdPath, webUrl)).to.be.true
 


### PR DESCRIPTION
The beginnings of a mock object to decouple UI testing from backend testing.
