### PR TITLE
When the browser refreshes, multiple copies of images are added to the image state causing a server crash

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -41,12 +41,16 @@ exp.get "/gallery", (req, res) ->
 State = image_src_list: []
 
 ccKlass = if process.env['STUB_CAMERA'] is "true" then StubCameraControl else CameraControl
+camera = new ccKlass().init()
+
+camera.on "photo_saved", (filename, path, web_url) ->
+    State.image_src_list.push path
 
 io = require("socket.io").listen(web)
 web.listen 3000
 io.sockets.on "connection", (websocket) ->
   sys.puts "Web browser connected"
-  camera = new ccKlass().init()
+  
   camera.on "camera_begin_snap", ->
     websocket.emit "camera_begin_snap"
 
@@ -54,7 +58,6 @@ io.sockets.on "connection", (websocket) ->
     websocket.emit "camera_snapped"
 
   camera.on "photo_saved", (filename, path, web_url) ->
-    State.image_src_list.push path
     websocket.emit "photo_saved",
       filename: filename
       path: path


### PR DESCRIPTION
I ran across a bug where sometimes the server would crash because the `image_src_list` was getting extra copies of images.

This resulted in an error message like the following:
```
img_src_list is: public/temp/test_photo.jpg,public/temp/test_photo.jpg,public/temp/test_photo.jpg,public/temp/test_photo.jpg,public/temp/test_photo.jpg,public/temp/test_photo.jpg,public/temp/test_photo.jpg,public/temp/test_photo.jpg,public/temp/test_photo.jpg,public/temp/test_photo.jpg,public/temp/test_photo.jpg,public/temp/test_photo.jpg,public/temp/test_photo.jpg,public/temp/test_photo.jpg,public/temp/test_photo.jpg,public/temp/test_photo.jpg
executing: convert -size 2550x1750 canvas:white public/temp/test_photo.jpg -geometry 1200x800+50+50 -composite public/temp/test_photo.jpg -geometry 1200x800+1300+50 -composite public/temp/test_photo.jpg -geometry 1200x800+50+900 -composite public/temp/test_photo.jpg -geometry 1200x800+1300+900 -composite public/temp/test_photo.jpg -geometry  -composite public/temp/test_photo.jpg -geometry  -composite public/temp/test_photo.jpg -geometry  -composite public/temp/test_photo.jpg -geometry  -composite public/temp/test_photo.jpg -geometry  -composite public/temp/test_photo.jpg -geometry  -composite public/temp/test_photo.jpg -geometry  -composite public/temp/test_photo.jpg -geometry  -composite public/temp/test_photo.jpg -geometry  -composite public/temp/test_photo.jpg -geometry  -composite public/temp/test_photo.jpg -geometry  -composite public/temp/test_photo.jpg -geometry  -composite public/temp/out.jpg

/Users/ben/Github/shmile-bsalinas/lib/image_compositor.coffee:64
              throw err;
                    ^
Error: Command failed: convert: invalid argument for option `-geometry': undefined @ error/convert.c/ConvertImageCommand/1674.

  at ChildProcess.<anonymous> (/Users/ben/Github/shmile-bsalinas/node_modules/imagemagick/imagemagick.js:88:15)
  at ChildProcess.emit (events.js:98:17)
  at maybeClose (child_process.js:756:16)
  at Socket.<anonymous> (child_process.js:969:11)
  at Socket.emit (events.js:95:17)
  at Pipe.close (net.js:465:12)
```

This resulted, in at least one case, from the browser refreshing. This caused a new websocket connection to be created, which caused a new camera to be created and the listener placed on that camera to trigger one for each connection that once existed.

I moved the camera constructor out of the websocket event, thinking that there should probably only be one camera object anyway. I also brought the code that adds images to the `State.image_src_list` outside of the websocket event so it only gets bound once. 

I haven't actually been able to test this with a real camera but it seems to solve the issue when using the simulated camera.